### PR TITLE
fix: submit selected proxy profile in batch editor

### DIFF
--- a/web/src/components/BatchEditor.test.tsx
+++ b/web/src/components/BatchEditor.test.tsx
@@ -3,6 +3,24 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BatchEditor } from "./BatchEditor";
 
+vi.mock("../api/client", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../api/client")>();
+	return {
+		...actual,
+		listProxyProfiles: vi.fn(async () => ({
+			profiles: [{
+				id: "proxy-primary",
+				name: "Primary proxy",
+				proxy_url_masked: "socks5://user:***@proxy.example:1080",
+				enabled: true,
+				account_count: 0,
+				created_at: "",
+				updated_at: "",
+			}],
+		})),
+	};
+});
+
 describe("BatchEditor", () => {
   beforeEach(() => cleanup());
 	const loadModels = async () => ({ models: [], total: 1, eligible: 1, loaded: 1, failed: 0, read_only: 0, missing: 0 });
@@ -19,6 +37,32 @@ describe("BatchEditor", () => {
 
     expect(submit).toHaveBeenCalledWith({ note: "batch-note" });
   });
+
+	it("submits a selected proxy profile instead of the redacted proxy value", async () => {
+		const user = userEvent.setup();
+		const submit = vi.fn();
+		const loadCurrentConfig = vi.fn(async () => ({
+			account_id: "auth-1",
+			disabled: false,
+			priority: 0,
+			note: "",
+			prefix: "",
+			proxy: "configured",
+			proxy_configured: true,
+			websockets: false,
+			header_names: [],
+			model_policy: null,
+		}));
+
+		render(<BatchEditor scopeLabel="account" loadModels={loadModels} loadCurrentConfig={loadCurrentConfig} onClose={() => undefined} onSubmit={submit} />);
+
+		await screen.findByText("当前账号配置");
+		await user.click(screen.getByRole("checkbox", { name: "代理 URL" }));
+		await user.selectOptions(screen.getByLabelText("代理档案"), "proxy-primary");
+		await user.click(screen.getByRole("button", { name: "生成预览" }));
+
+		expect(submit).toHaveBeenCalledWith({ proxy_profile_id: "proxy-primary" });
+	});
 
 	it("submits both account request-window limits independently", async () => {
 		const user = userEvent.setup();

--- a/web/src/components/BatchEditor.tsx
+++ b/web/src/components/BatchEditor.tsx
@@ -245,7 +245,10 @@ export function BatchEditor({ title = "ui.batch_edit", scopeLabel, onClose, onSu
 		}
     if (enabled.note) patch.note = note;
     if (enabled.prefix) patch.prefix = prefix;
-    if (enabled.proxy_url) patch.proxy_url = proxyURL;
+    if (enabled.proxy_url) {
+			if (proxyProfileID) patch.proxy_profile_id = proxyProfileID;
+			else patch.proxy_url = proxyURL;
+		}
     if (enabled.websockets) patch.websockets = websockets;
 		if (enabled.codex_identity) {
 			patch.codex_identity = {


### PR DESCRIPTION
## Summary

- submit `proxy_profile_id` when a reusable proxy profile is selected in the account batch editor
- keep submitting `proxy_url` only for the manual proxy input path
- add a regression test covering an account whose current proxy is returned as the redacted `configured` display value

## Problem

Selecting a reusable proxy profile only updated the local `proxyProfileID` state. The submit handler ignored that state and always sent the value held in `proxyURL`.

For an account configured with `direct`, the account API redacts the non-URL value to `configured`. Selecting a profile and generating a preview therefore sent:

```json
{"proxy_url":"configured"}
```

The backend correctly rejected that value with:

```text
proxy_url must be empty, direct, none, or a valid proxy URL
```

Even when the redacted display value happens to parse as a URL, sending it instead of the profile ID can lose proxy credentials or apply the wrong value.

## Fix

Make the two editor paths mutually exclusive at submission time:

- selected reusable profile -> `proxy_profile_id`
- manual input -> `proxy_url`

## Validation

- `npm test -- --run src/components/BatchEditor.test.tsx` (8/8 passed)
- `npm run typecheck` (passed)
